### PR TITLE
Enable use of css modules

### DIFF
--- a/client/components/App/App.scss
+++ b/client/components/App/App.scss
@@ -1,44 +1,28 @@
-@import '../../../node_modules/normalize.css/normalize.css';
-@import '../../../node_modules/react-mdl/extra/css/material.cyan-red.min.css';
 @import url('https://fonts.googleapis.com/icon?family=Material+Icons');
 @import '../variables.scss';
 
-.app {
+.root {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
 }
 
-h1 {
+.greeting {
+  background-color: $blue;
+  color: $white;
+  height: 330px;
+  padding-top: 50px;
+  text-align: center;
+}
+
+.sawasdee {
   font-size: 2.5em;
   font-weight: normal;
-}
-
-h2 {
-  font-size: 2em;
-  font-weight: normal;
-}
-
-.greeting {
-  text-align: center;
-  padding-top: 50px;
-  height: 330px;
-  color: $white;
-  background-color: $blue;
 }
 
 .content {
   flex: 1;
   margin: 10px 50px;
-
-  .tools {
-    img {
-      padding: 13px;
-      width: 55px;
-      height: 55px;
-      text-align: center;
-    }
-  }
 }
 
 /**

--- a/client/components/App/AppComponent.js
+++ b/client/components/App/AppComponent.js
@@ -1,7 +1,9 @@
 import React from 'react';
+import 'normalize.css/normalize.css';
+import 'react-mdl/extra/css/material.cyan-red.min.css';
 import Navbar from '../Navbar/NavbarComponent';
 import Footer from '../Footer/FooterContainer';
-import './App.scss';
+import styles from './App.scss';
 import yeoman from '../../assets/yeoman.png';
 
 export default class App extends React.Component {
@@ -12,14 +14,14 @@ export default class App extends React.Component {
 
   render() {
     return (
-      <div className='app'>
+      <div className={styles.root}>
         <Navbar />
-        <div className='greeting'>
-          <h1>Sawasdee, Sawasdee!</h1>
+        <div className={styles.greeting}>
+          <h1 className={styles.sawasdee}>Sawasdee, Sawasdee!</h1>
           <p>Always a pleasure scaffolding your apps</p>
           <img src={yeoman} alt='yeoman' />
         </div>
-        <div className='content'>
+        <div className={styles.content}>
           {this.props.children}
         </div>
         <Footer viewer={this.props.viewer} />
@@ -27,4 +29,3 @@ export default class App extends React.Component {
     );
   }
 }
-

--- a/client/components/Feature/Feature.scss
+++ b/client/components/Feature/Feature.scss
@@ -1,0 +1,21 @@
+.card {
+  margin: auto;
+  width: 250px;
+}
+
+.image {
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 40% !important;
+}
+
+.name {
+  padding: 0;
+  text-align: center;
+}
+
+.description {
+  padding-bottom: 30px;
+  padding-top: 0;
+  text-align: center;
+}

--- a/client/components/Feature/FeatureComponent.js
+++ b/client/components/Feature/FeatureComponent.js
@@ -1,6 +1,8 @@
 /* eslint-disable global-require */
 import React from 'react';
 import { Grid, Cell, Card, CardTitle, CardText, CardActions, Button } from 'react-mdl';
+import Page from '../Page/PageComponent';
+import styles from './Feature.scss';
 
 export default class Feature extends React.Component {
   static propTypes = {
@@ -9,20 +11,18 @@ export default class Feature extends React.Component {
 
   render() {
     return (
-      <div>
-        <h2>Integrated with</h2>
-        <hr />
-        <Grid className='tools'>
+      <Page heading='Integrated with'>
+        <Grid>
           {this.props.viewer.features.edges.map(edge => {
             const imageUrl = require(`../../assets/${edge.node.name.toLowerCase()}.png`);
             return (
               <Cell col={4} key={edge.node.id}>
-                <Card style={{ width: '250px', margin: 'auto' }}>
-                  <CardTitle expand style={{ color: '#ccc', background: `url(${imageUrl}) center no-repeat`, backgroundSize: '40%' }} />
-                  <CardActions style={{ textAlign: 'center', padding: 0 }}>
+                <Card className={styles.card}>
+                  <CardTitle expand className={styles.image} style={{ backgroundImage: `url(${imageUrl})` }} />
+                  <CardActions className={styles.name}>
                     <Button colored href={edge.node.url}>{edge.node.name}</Button>
                   </CardActions>
-                  <CardText style={{ textAlign: 'center', paddingTop: 0, paddingBottom: '30px' }}>
+                  <CardText className={styles.description}>
                     {edge.node.description}
                   </CardText>
                 </Card>
@@ -30,7 +30,7 @@ export default class Feature extends React.Component {
             );
           })}
         </Grid>
-      </div>
+      </Page>
     );
   }
 }

--- a/client/components/Footer/Footer.scss
+++ b/client/components/Footer/Footer.scss
@@ -1,13 +1,12 @@
 @import '../variables.scss';
 
-.mdl-mini-footer {
-  padding: 30px 16px !important;
+.root {
   background-color: $black-light !important;
   justify-content: center !important;
+  padding: 30px 16px !important;
 
   a {
     color: $white;
     text-decoration: none;
   }
 }
-

--- a/client/components/Footer/FooterComponent.js
+++ b/client/components/Footer/FooterComponent.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Footer as MDLFooter, FooterSection } from 'react-mdl';
-import './Footer.scss';
+import styles from './Footer.scss';
 
 export default class Footer extends React.Component {
   static propTypes = {
@@ -9,7 +9,7 @@ export default class Footer extends React.Component {
 
   render() {
     return (
-      <MDLFooter size='mini'>
+      <MDLFooter className={styles.root} size='mini'>
         <FooterSection type='middle'>
           <span>Handcrafted with ♥ by <a href={this.props.viewer.website}> @{this.props.viewer.username}</a></span>
         </FooterSection>

--- a/client/components/Login/LoginComponent.js
+++ b/client/components/Login/LoginComponent.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import { Grid, Cell, Textfield, Button, Checkbox } from 'react-mdl';
+import Page from '../Page/PageComponent';
 
 export default class Login extends React.Component {
   render() {
     return (
-      <div>
-        <h1>Login</h1>
-        <hr />
+      <Page heading='Login'>
         <div style={{ width: '70%', margin: 'auto' }}>
           <Grid>
             <form style={{ margin: 'auto' }}>
@@ -26,7 +25,7 @@ export default class Login extends React.Component {
             </form>
           </Grid>
         </div>
-      </div>
+      </Page>
     );
   }
 }

--- a/client/components/Navbar/Navbar.scss
+++ b/client/components/Navbar/Navbar.scss
@@ -1,21 +1,22 @@
 @import '../variables.scss';
 
-.mdl-layout-title a {
-  color: $white;
-  text-decoration: none;
-  font-weight: normal;
-}
+.root :global {
+  .mdl-layout-title a {
+    color: $white;
+    text-decoration: none;
+    font-weight: normal;
+  }
 
-.mdl-layout__header-row .mdl-navigation__link {
-  color: $white !important;
-}
+  .mdl-layout__header-row .mdl-navigation__link {
+    color: $white !important;
+  }
 
-.mdl-layout__drawer > .mdl-layout-title {
-  padding-top: 36px;
-  background-color: $blue;
-}
+  .mdl-layout__drawer > .mdl-layout-title {
+    padding-top: 36px;
+    background-color: $blue;
+  }
 
-.mdl-layout__drawer-button {
-  color: $white !important;
+  .mdl-layout__drawer-button {
+    color: $white !important;
+  }
 }
-

--- a/client/components/Navbar/NavbarComponent.js
+++ b/client/components/Navbar/NavbarComponent.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Link } from 'react-router';
 import { Layout, Header, Navigation, Drawer } from 'react-mdl';
-import './Navbar.scss';
+import styles from './Navbar.scss';
 
 export default class Navbar extends React.Component {
   render() {
     const title = 'Relay Fullstack';
     return (
-      <Layout>
+      <Layout className={styles.root}>
         <Header title={<Link to='/'>{title}</Link>} scroll>
           <Navigation>
             <Link to='/signup'>Sign up</Link>
@@ -24,4 +24,3 @@ export default class Navbar extends React.Component {
     );
   }
 }
-

--- a/client/components/Page/Page.scss
+++ b/client/components/Page/Page.scss
@@ -1,0 +1,4 @@
+.heading {
+  font-size: 2em;
+  font-weight: normal;
+}

--- a/client/components/Page/PageComponent.js
+++ b/client/components/Page/PageComponent.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import styles from './Page.scss';
+
+export default class Feature extends React.Component {
+  static propTypes = {
+    children: React.PropTypes.element.isRequired,
+    heading: React.PropTypes.string.isRequired
+  };
+
+  render() {
+    return (
+      <div>
+        <h1 className={styles.heading}>
+          {this.props.heading}
+        </h1>
+        <hr />
+        {this.props.children}
+      </div>
+    );
+  }
+}

--- a/client/components/Signup/SignupComponent.js
+++ b/client/components/Signup/SignupComponent.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import { Grid, Cell, Textfield, Button } from 'react-mdl';
+import Page from '../Page/PageComponent';
 
 export default class Signup extends React.Component {
   render() {
     return (
-      <div>
-        <h1>Signup</h1>
-        <hr />
+      <Page heading='Signup'>
         <div style={{ width: '70%', margin: 'auto' }}>
           <Grid>
             <form style={{ margin: 'auto' }}>
@@ -22,7 +21,7 @@ export default class Signup extends React.Component {
             </form>
           </Grid>
         </div>
-      </div>
+      </Page>
     );
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,8 +26,15 @@ module.exports = {
       loader: 'babel-loader',
       exclude: /node_modules/
     }, {
+      test: /\.css$/,
+      loaders: ['style', 'css']
+    }, {
       test: /\.scss$/,
-      loaders: ['style-loader', 'css-loader', 'postcss-loader']
+      loaders: [
+        'style',
+        'css?modules&importLoaders=1' +
+          '&localIdentName=[name]__[local]___[hash:base64:5]!postcss'
+      ]
     }, {
       test: /\.(png|jpg|jpeg|gif|svg|woff|woff2)$/,
       loader: 'url-loader?limit=10000&name=assets/[hash].[ext]'
@@ -48,4 +55,3 @@ module.exports = {
     })
   ]
 };
-

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -24,8 +24,15 @@ module.exports = {
       loader: 'babel-loader',
       exclude: /node_modules/
     }, {
+      test: /\.css$/,
+      loaders: ['style', 'css']
+    }, {
       test: /\.scss$/,
-      loaders: ['style-loader', 'css-loader', 'postcss-loader']
+      loaders: [
+        'style',
+        'css?modules&importLoaders=1' +
+          '&localIdentName=[name]__[local]___[hash:base64:5]!postcss'
+      ]
     }, {
       test: /\.(png|jpg|jpeg|gif|svg|woff|woff2)$/,
       loader: 'url-loader?limit=10000&name=assets/[hash].[ext]'
@@ -57,4 +64,3 @@ module.exports = {
     })
   ]
 };
-


### PR DESCRIPTION
- Configure css-modules for .sass files
- Add a generic css loader configuration for vendor styles
- Refactor to demonstrate some example usage of css-modules

For more information on css-modules:
- https://github.com/css-modules/css-modules
- http://glenmaddern.com/articles/css-modules
- https://github.com/css-modules/webpack-demo
