### PR TITLE
name_of_your_app and trailing whitespace in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![devDependency Status](https://img.shields.io/david/dev/lvarayut/relay-fullstack.svg)](https://github.com/lvarayut/relay-fullstack)
 > Relay Fullstack is a Relay scaffolding application that aims to help you get up and running a project without worrying about integrating tools. It comes with many modern technologies; Relay, GraphQL, Express, ES6/ES7, JSX, Webpack, Babel, Material Design Lite, and PostCSS. Relay Fullstack is also using [Hot-reload](https://github.com/gaearon/react-transform-hmr) to real time update the screen whenever any code changes.
 
-## Example 
+## Example
 ![Demo](https://cloud.githubusercontent.com/assets/4281887/13377800/9c4705a2-de1d-11e5-82cb-745e16d5b1c4.gif)
 > Check out the [Live demo](http://relay-fullstack.herokuapp.com) on Heroku.
 
@@ -32,7 +32,7 @@ $ npm install
 $ npm start
 ```
 
-Launch your favorite web browser and go to `http://localhost:3000` for Relay application or `http://localhost:8000` for GraphiQL. 
+Launch your favorite web browser and go to `http://localhost:3000` for Relay application or `http://localhost:8000` for GraphiQL.
 
 ### Advance
 
@@ -52,7 +52,7 @@ $ yo relay-fullstack
 $ npm start
 ```
 
-Launch your favorite web browser and go to `http://localhost:3000` for Relay application or `http://localhost:8000` for GraphiQL. 
+Launch your favorite web browser and go to `http://localhost:3000` for Relay application or `http://localhost:8000` for GraphiQL.
 
 > NOTE: generator-relay-fullstack is currently working with minimal functionalities. Database, Flow, and Sub-generator are work-in-progress.
 
@@ -71,7 +71,7 @@ Again, launch your favorite web browser and go to `http://localhost:3000`.
 Before getting started, make sure you already installed the [Heroku Toolbelt](https://toolbelt.heroku.com), which is a command-line tooling for managing Heroku applications that makes it easy to deploy an application in a few steps:
 
 ```bash
-$ heroku create                     # Create a new Heroku application
+$ heroku create NAME_OF_YOUR_APP    # Create a new Heroku application
 $ git push heroku master            # Push your code into the created Heroku repository
 $ heroku ps:scale web=1             # Run the deployed application
 ````
@@ -93,24 +93,24 @@ $ npm run update
     │   ├── assets                      - Images and fonts
     │   ├── components                  - Relay containers, React components, and SCSS files used in the components
     │   │   └── variables.scss          - Common SCSS variables
-    │   ├── routes                      - React-router-relay 
+    │   ├── routes                      - React-router-relay
     │   │   ├── Route.js                - All route definitions
     │   │   └── ViewerQuery.js          - Entry node of a GraphQL query
-    │   ├── index.html                  - HTML template file used by html-webpack-plugin 
+    │   ├── index.html                  - HTML template file used by html-webpack-plugin
     │   └── index.js                    - Client entry point
     ├── server                          - All of the server side code resides in this folder
-    │   ├── config                      - Configuration 
+    │   ├── config                      - Configuration
     │   │   └── environment             - Separate configuration for each environment
     │   │       ├── development.js      - Development configuration
     │   │       ├── index.js            - Common configuration used in any environment
     │   │       ├── production.js       - Production configuration
     │   │       └── test.js             - Test configuration
-    │   ├── data                        - Data and APIs 
+    │   ├── data                        - Data and APIs
     │   │   ├── database.js             - Mock up database which should be replaced with your real database logic
     │   │   ├── schema.graphql          - Compiled schema in a readable form
     │   │   ├── schema.js               - Schema definitions
-    │   │   └── schema.json             - Compiled schema to be used by Relay 
-    │   ├── utils                       - Utilities 
+    │   │   └── schema.json             - Compiled schema to be used by Relay
+    │   ├── utils                       - Utilities
     │   │   ├── babelRelayPlugin.js     - Babel-relay-plugin provided by Relay
     │   │   └── updateSchema.js         - Code for compiling the defined schema to schema.json and schema.graphql
     │   └── index.js                    - Server entry point
@@ -128,7 +128,7 @@ $ npm run update
 
 [Express](http://expressjs.com/) - Express is a minimal and flexible Node.js web application framework that provides a robust set of features for web and mobile applications.
 
-### Module bundler & Syntax transformers 
+### Module bundler & Syntax transformers
 [Webpack](https://webpack.github.io) - Webpack is a module bundler that takes modules with dependencies and generates static assets representing those modules.
 
 [Babel](https://babeljs.io) - Babel is a JavaScript compiler which allows you to  use next generation, ES6/ES7, JavaScript, today.


### PR DESCRIPTION
I think it is better to advise user to add app name in heroku create command because heroku create ugly names but in the same time user 100% has his own name for app.
Plus my linter have removed some trailing whitespace in document.
