### PR TITLE
Remove --ignore-path from eslint config

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "update": "./node_modules/.bin/babel-node server/utils/updateSchema.js",
     "deploy": "npm run clean && cross-env NODE_ENV=production webpack --config webpack.config.js && npm run update && npm run build-server && cross-env NODE_ENV=production node ./build/index.js",
     "build-server": "cross-env NODE_ENV=production ./node_modules/.bin/babel ./server --out-dir ./build",
-    "lint": "eslint --ignore-path .gitignore client server",
+    "lint": "eslint client server",
     "heroku-postbuild": "cross-env NODE_ENV=production webpack --config webpack.config.js && cross-env NODE_ENV=production ./node_modules/.bin/babel ./server --out-dir ./lib",
     "clean": "rm -rf build && mkdir build"
   },


### PR DESCRIPTION
We currently have `--ignore-path` set in the eslint hook for git commits. This forces eslint to ignore the `.eslintignore` file, which is the standard way of specifying files & folders you don't want to be linted.

I was trying to add `.eslintignore` to my repo and spent a while trying to figure out why my files were still being linted. It's unintuitive to have this flag set by default.

ps. we probably shouldn't be linting the .gitignore file either :P 