### PR TITLE
React PropTypes

### DIFF
--- a/client/components/App/AppComponent.js
+++ b/client/components/App/AppComponent.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import 'normalize.css/normalize.css';
 import 'react-mdl/extra/css/material.cyan-red.min.css';
 import Navbar from '../Navbar/NavbarComponent';
@@ -8,8 +9,8 @@ import yeoman from '../../assets/yeoman.png';
 
 export default class App extends React.Component {
   static propTypes = {
-    children: React.PropTypes.object.isRequired,
-    viewer: React.PropTypes.object.isRequired
+    children: PropTypes.object.isRequired,
+    viewer: PropTypes.object.isRequired
   };
 
   render() {

--- a/client/components/Feature/AddFeatureComponent.js
+++ b/client/components/Feature/AddFeatureComponent.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import Dropdown from 'react-dropdown';
 import { Grid, Cell, Button } from 'react-mdl';
@@ -20,7 +21,7 @@ const inputData = {
 
 export default class Feature extends React.Component {
   static propTypes = {
-    viewer: React.PropTypes.object.isRequired
+    viewer: PropTypes.object.isRequired
   };
 
   state = {

--- a/client/components/Feature/FeatureComponent.js
+++ b/client/components/Feature/FeatureComponent.js
@@ -1,5 +1,6 @@
 /* eslint-disable global-require */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Grid, Cell, Card, CardTitle, CardText, CardActions, Button } from 'react-mdl';
 import Page from '../Page/PageComponent';
 import styles from './Feature.scss';
@@ -7,7 +8,7 @@ import AddFeature from './AddFeatureComponent';
 
 export default class Feature extends React.Component {
   static propTypes = {
-    viewer: React.PropTypes.object.isRequired
+    viewer: PropTypes.object.isRequired
   };
 
   render() {

--- a/client/components/Footer/FooterComponent.js
+++ b/client/components/Footer/FooterComponent.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Footer as MDLFooter, FooterSection } from 'react-mdl';
 import styles from './Footer.scss';
 
 export default class Footer extends React.Component {
   static propTypes = {
-    viewer: React.PropTypes.object.isRequired,
+    viewer: PropTypes.object.isRequired,
   };
 
   render() {

--- a/client/components/Page/PageComponent.js
+++ b/client/components/Page/PageComponent.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import styles from './Page.scss';
 
 export default class Feature extends React.Component {
   static propTypes = {
-    children: React.PropTypes.element.isRequired,
-    heading: React.PropTypes.string.isRequired
+    children: PropTypes.element.isRequired,
+    heading: PropTypes.string.isRequired
   };
 
   render() {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "normalize.css": "^5.0.0",
     "postcss-loader": "^1.2.1",
     "precss": "^1.4.0",
+    "prop-types": "^15.5.4",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
     "react-dropdown": "^1.2.0",


### PR DESCRIPTION
* FB deprecated prop-types in the main react package and has a new package prop-types instead
* Ran codemod "jscodeshift -t react-codemod/transforms/React-PropTypes-to-prop-types.js <path>"
* Dependencies still have warnings
#84 